### PR TITLE
feat(#59): change nome label to nome completo and validate

### DIFF
--- a/src/components/organisms/FormCadastro/index.tsx
+++ b/src/components/organisms/FormCadastro/index.tsx
@@ -79,7 +79,11 @@ export function FormCadastro(props: {
       .required(ERRORS.REQUIRED_NAME)
       .trim()
       .min(MIN_LENGTH_NAME_VALUE, ERRORS.MIN_LENGHT_NAME)
-      .max(MAX_LENGTH_NAME_VALUE, ERRORS.MAX_LENGHT_NAME),
+      .max(MAX_LENGTH_NAME_VALUE, ERRORS.MAX_LENGHT_NAME)
+      .matches(
+        /\b[A-Za-zÀ-ú][A-Za-zÀ-ú]+,?\s[A-Za-zÀ-ú][A-Za-zÀ-ú]{2,19}\b/gi,
+        'Por favor, informe seu nome completo'
+      ),
     email: Yup.string()
       .email(ERRORS.INVALID_EMAIL)
       .required(ERRORS.REQUIRED_EMAIL),
@@ -135,7 +139,7 @@ export function FormCadastro(props: {
   return (
     <S.Form onSubmit={handleSubmit(onSubmit)}>
       <TextField
-        label="Nome"
+        label="Nome Completo"
         maxLength={MAX_LENGTH_NAME_VALUE}
         error={errors.name?.message}
         required={true}

--- a/src/components/organisms/FormCadastro/test.tsx
+++ b/src/components/organisms/FormCadastro/test.tsx
@@ -29,7 +29,7 @@ describe('<FormCadastro/>', () => {
 
   const elements = () => {
     return {
-      name: screen.getByRole('textbox', { name: 'Nome' }),
+      name: screen.getByRole('textbox', { name: 'Nome Completo' }),
       email: screen.getByRole('textbox', { name: 'E-mail' }),
       password: screen.getByRole('password', { name: 'Senha' }),
       confirm: screen.getByRole('password', { name: 'Confirmar Senha' }),
@@ -51,7 +51,7 @@ describe('<FormCadastro/>', () => {
       termsConfirm
     } = elements()
 
-    userEvent.type(name, 'Nome')
+    userEvent.type(name, 'Nome Completo')
     userEvent.type(email, 'teste@teste.com')
     userEvent.type(password, '!@#ASD!@#AASASD')
     userEvent.type(confirm, '!@#ASD!@#AASASD')
@@ -97,6 +97,16 @@ describe('<FormCadastro/>', () => {
       expect(screen.getByText(/Nome é obrigatório/)).toBeInTheDocument()
     })
   })
+  it('when inserting an incomplete name', async () => {
+    const { name, buttonCadastrar } = elements()
+    userEvent.type(name, 'Nome')
+    fireEvent.click(buttonCadastrar)
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Por favor, informe seu nome completo/)
+      ).toBeInTheDocument()
+    })
+  })
   it('when inserting an invalid email', async () => {
     const { email, buttonCadastrar } = elements()
     userEvent.type(email, 'email')
@@ -131,7 +141,7 @@ describe('<FormCadastro/>', () => {
 
     await waitFor(() => {
       expect(signupServiceMock.initialSignup).toBeCalledWith({
-        nome: 'Nome',
+        nome: 'Nome Completo',
         email: 'teste@teste.com',
         senha: '!@#ASD!@#AASASD',
         tipo: UserType.ALUNO


### PR DESCRIPTION
This PR has the current changes:

In User register form, changed the label for **Nome** to **Nome completo**
Added a regex validation to the name input with the following rules:
- Required to be 2 strings
- Each string should have at least 3 chars

| Before   |      After      | 
|----------|:-------------:|
|<img width="543" alt="image" src="https://user-images.githubusercontent.com/94059872/170279110-e4535b1a-97f7-4bd4-b88a-f9877a7f39f4.png"> |  <img width="543" alt="image" src="https://user-images.githubusercontent.com/94059872/170278587-b6b3313b-18e2-4787-ad94-577b2935ebae.png"> |


